### PR TITLE
add second lifetime for value decoupled from key when querying for `Interval`s

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -28,15 +28,15 @@ impl<'a, T: Ord + 'a, V: 'a> Entry<'a, T, V> {
 /// An `IntervalTreeIterator` is returned by `Intervaltree::find` and iterates over the entries
 /// overlapping the query
 #[derive(Debug)]
-pub struct IntervalTreeIterator<'a, T: Ord, V> {
-    pub(crate) nodes: Vec<&'a Node<T, V>>,
-    pub(crate) interval: &'a Interval<T>,
+pub struct IntervalTreeIterator<'v, 'i, T: Ord, V> {
+    pub(crate) nodes: Vec<&'v Node<T, V>>,
+    pub(crate) interval: &'i Interval<T>,
 }
 
-impl<'a, T: Ord + 'a, V: 'a> Iterator for IntervalTreeIterator<'a, T, V> {
-    type Item = Entry<'a, T, V>;
+impl<'v, 'i, T: Ord + 'i, V: 'v> Iterator for IntervalTreeIterator<'v, 'i, T, V> {
+    type Item = Entry<'v, T, V>;
 
-    fn next(&mut self) -> Option<Entry<'a, T, V>> {
+    fn next(&mut self) -> Option<Entry<'v, T, V>> {
         loop {
             let node_ref = match self.nodes.pop() {
                 None => return None,
@@ -90,15 +90,15 @@ impl<'a, T: Ord + 'a, V: 'a> EntryMut<'a, T, V> {
 /// An `IntervalTreeIteratorMut` is returned by `Intervaltree::find_mut` and iterates over the entries
 /// overlapping the query allowing mutable access to the data `D`, not the `Interval`.
 #[derive(Debug)]
-pub struct IntervalTreeIteratorMut<'a, T: Ord, V> {
-    pub(crate) nodes: Vec<&'a mut Node<T, V>>,
-    pub(crate) interval: &'a Interval<T>,
+pub struct IntervalTreeIteratorMut<'v, 'i, T: Ord, V> {
+    pub(crate) nodes: Vec<&'v mut Node<T, V>>,
+    pub(crate) interval: &'i Interval<T>,
 }
 
-impl<'a, T: Ord + 'a, V: 'a> Iterator for IntervalTreeIteratorMut<'a, T, V> {
-    type Item = EntryMut<'a, T, V>;
+impl<'v, 'i, T: Ord + 'i, V: 'v> Iterator for IntervalTreeIteratorMut<'v, 'i, T, V> {
+    type Item = EntryMut<'v, T, V>;
 
-    fn next(&mut self) -> Option<EntryMut<'a, T, V>> {
+    fn next(&mut self) -> Option<EntryMut<'v, T, V>> {
         loop {
             let node_ref = match self.nodes.pop() {
                 None => return None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,13 @@ impl<T: Ord, V> IntervalTree<T, V> {
     /// assert!(interval_tree.find_overlap(&Interval::new(Excluded(10), Excluded(15))).is_none());
     /// ```
     #[must_use]
-    pub fn query<'a, 'b>(&'a self, interval: &'b Interval<T>) -> IntervalTreeIterator<'b, T, V>
+    pub fn query<'a, 'v, 'i>(
+        &'a self,
+        interval: &'i Interval<T>,
+    ) -> IntervalTreeIterator<'v, 'i, T, V>
     where
-        'a: 'b,
+        'a: 'v,
+        'a: 'i,
     {
         if let Some(ref n) = self.root {
             IntervalTreeIterator {
@@ -201,12 +205,13 @@ impl<T: Ord, V> IntervalTree<T, V> {
     /// // there is no interval in the tree that has interval with (10,15)
     /// assert!(interval_tree.find_overlap(&Interval::new(Excluded(10), Excluded(15))).is_none());
     /// ```
-    pub fn query_mut<'a, 'b>(
+    pub fn query_mut<'a, 'v, 'i>(
         &'a mut self,
-        interval: &'b Interval<T>,
-    ) -> IntervalTreeIteratorMut<'b, T, V>
+        interval: &'i Interval<T>,
+    ) -> IntervalTreeIteratorMut<'v, 'i, T, V>
     where
-        'a: 'b,
+        'a: 'v,
+        'a: 'i,
     {
         if let Some(ref mut n) = self.root {
             IntervalTreeIteratorMut {


### PR DESCRIPTION
Because the `Interval` to query provided to `query()` and `query_mut()` share the same lifetime with value type `V` (`'a`), it is currently not possible, for example, to construct an `Interval` in a function, feed it into `query()` and return the resulting `IntervalTreeIterator` from the function, e.g. this is not possible:

```rust
fn foo(tree: &IntervalTree<int, ()>) -> impl Iterator<Item = ()> {
    let i = Interval::new(Bound::Included(21), Bound::Excluded(42));
    
    tree.query(&i)
}

...

let tree = IntervalTree<int, ()>::new()
...
let values: Vec<_> = foo(&tree).collect();
```
because `i` has to live just as long as the values collected to `values` (which it cannot).

By replacing the single lifetime `'a` with two lifetimes, `'v` for the values and `'i` for the interval queried, one could circumvent this problem.

Cheers